### PR TITLE
fix: airflow-scheduler LOAD_EXAMPLES=False 누락 수정 (#16)

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -109,6 +109,7 @@ services:
     environment:
       - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
       - AIRFLOW__CORE__EXECUTOR=LocalExecutor
+      - AIRFLOW__CORE__LOAD_EXAMPLES=False
     volumes:
       - ..:/app
       - ./dags:/opt/airflow/dags


### PR DESCRIPTION
## Summary
- `airflow-scheduler` environment에 `AIRFLOW__CORE__LOAD_EXAMPLES=False` 추가
- `airflow-init`, `airflow-webserver`에는 있었으나 `airflow-scheduler`에만 누락되어 있었음
- Closes #16

## Test plan
- [ ] `docker compose down -v` 후 `docker compose -f docker/compose.yml up -d` 재기동
- [ ] `localhost:8082` 접속 → `daily_ga4_ingestion` DAG만 표시되는지 확인 (예시 DAG 없어야 함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)