### PR TITLE
chore: .gitignore에 /credentials 패턴 추가로 GCP 서비스 계정 키 보호

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ checkpoint.txt
 
 # data files
 /data
+
+# Authentication
+/credentials


### PR DESCRIPTION
## Summary
- GCP 서비스 계정 키 파일이 실수로 원격 저장소에 업로드되지 않도록 `.gitignore`에 `/credentials` 패턴 추가

## 변경 내용
- `.gitignore`: `/credentials` 디렉터리 및 하위 파일 전체 무시 처리

## Test plan
- [ ] `credentials/` 경로에 임시 파일 생성 후 `git status`에서 untracked로 표시되지 않는지 확인

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)