### PR TITLE
이탈 구매예측 ml_predict 통합 

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -119,7 +119,8 @@ services:
   spark-master:
     image: apache/spark:3.5.1
     container_name: spark-master
-    command: ["/opt/spark/bin/spark-class", "org.apache.spark.deploy.master.Master"]
+    command:
+      ["/opt/spark/bin/spark-class", "org.apache.spark.deploy.master.Master"]
     ports:
       - "7077:7077"
       - "8080:8080"
@@ -133,7 +134,12 @@ services:
     container_name: spark-worker
     depends_on:
       - spark-master
-    command: ["/opt/spark/bin/spark-class", "org.apache.spark.deploy.worker.Worker", "spark://spark-master:7077"]
+    command:
+      [
+        "/opt/spark/bin/spark-class",
+        "org.apache.spark.deploy.worker.Worker",
+        "spark://spark-master:7077",
+      ]
     ports:
       - "8081:8081"
     environment:

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -22,3 +22,4 @@ xgboost
 lightgbm
 catboost
 joblib
+polars

--- a/output/t8_prediction_trend.csv
+++ b/output/t8_prediction_trend.csv
@@ -1,0 +1,2 @@
+prediction_date,total_users,predicted_purchasers,predicted_purchase_rate,avg_purchase_probability,high_value_count,high_risk_count,actual_sessions,actual_revenue,trend_purchase_rate
+2026-03-05,270155,4092,0.015146860135847939,0.015373491045903557,4132,0,360130,479010000.0,0.05910310747533823

--- a/src/ML/ml_predict.py
+++ b/src/ML/ml_predict.py
@@ -7,15 +7,21 @@ import datetime
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import StandardScaler
 from sklearn.pipeline import make_pipeline
+import polars as pl
 
 # 1. 설정값
-MODEL_PATH = "/app/src/ML/models/purchase_model.pkl"
+CHURN_MODEL_PATH = "/app/src/ML/models/churn_model.pkl"
+PURCHASE_MODEL_PATH = "/app/src/ML/models/purchase_model.pkl"
 INPUT_PATH = "/app/data/raw/raw_data_with_gmt.csv"
 OUTPUT_DIR = "/app/output"
-THRESHOLD = 0.825
+P_THRESHOLD = 0.825
+C_THRESHOLD = 0.65
+
 
 def load_and_preprocess():
     print("Step 1: 데이터 로드 및 전처리 시작...", flush=True)
+
+    # [1] 사용할 컬럼 및 데이터 타입 정의  > 메모리 절감 
     actual_cols = [
         "user_pseudo_id", "event_name", "event_timestamp", "event_date",
         "param_engagement_time_msec", "param_ga_session_id",
@@ -23,89 +29,167 @@ def load_and_preprocess():
         "param_percent_scrolled", "param_outbound", "param_search_term"
     ]
 
-    # 1. 읽어올 때부터 타입을 지정해서 메모리 사용량 60% 절감
-    dtype_dict = {
-        "user_pseudo_id": "object",
-        "event_name": "category",  # 반복되는 문자열은 카테고리가 훨씬 가벼움
-        "param_outbound": "object",
-        "param_page_location": "object"
+    dtype_overrides = {
+        "user_pseudo_id": pl.Utf8,
+        "event_name": pl.Utf8, 
+        "param_outbound": pl.Utf8,
+        "param_page_location": pl.Utf8,
+        "param_engagement_time_msec": pl.Float64,
+        "param_percent_scrolled": pl.Float64
     }
+    
+    # [2] Lazy 스캔 및 1단계 변환 (Projection Pushdown 적용)
+    # print(f"✅ 로드 완료 ({len(df)} 행). 전처리 및 타입 변환 중...", flush=True)
+    # df = pd.read_csv(INPUT_PATH, usecols=actual_cols, dtype=dtype_dict, low_memory=False)
+    # df = df.head(10000)
 
-    df = pd.read_csv(INPUT_PATH, usecols=actual_cols, dtype=dtype_dict, low_memory=False)
-    df = df.head(10000)
-    print(f"✅ 로드 완료 ({len(df)} 행). 전처리 및 타입 변환 중...", flush=True)
-
-    df["is_page_view"] = (df["event_name"] == "page_view").astype(int)
-    df["is_purchase"] = (df["event_name"] == "purchase").astype(int)
-    df["is_add_to_cart"] = (df["event_name"] == "add_to_cart").astype(int)
-
-    df["param_engagement_time_msec"] = pd.to_numeric(df["param_engagement_time_msec"], errors="coerce").fillna(0)
-    df["param_percent_scrolled"] = pd.to_numeric(df["param_percent_scrolled"], errors="coerce").fillna(0)
-    df["param_ga_session_number"] = pd.to_numeric(df["param_ga_session_number"], errors="coerce").fillna(0)
-    df["param_outbound_bool"] = df["param_outbound"].astype(str).str.lower().isin(["true", "1", "t", "yes"])
-    print("Loaded df:", df.shape, flush=True)
-
-    print("Step 1-2: 유저별 피처 집계 중...", flush=True)
-    features = df.groupby("user_pseudo_id", as_index=False).agg(
-        total_events=("event_timestamp", "count"),
-        total_page_views=("is_page_view", "sum"),
-        add_to_cart_count=("is_add_to_cart", "sum"),
-        purchase_count=("is_purchase", "sum"),
-        avg_engagement_time_msec=("param_engagement_time_msec", "mean"),
-        ga_session_id_count=("param_ga_session_id", "nunique"),
-        unique_pages=("param_page_location", "nunique"),
-        avg_session_number=("param_ga_session_number", "mean"),
-        scroll_count=("param_percent_scrolled", lambda s: (s >= 50).sum()),
-        engaged_cnt=("param_engagement_time_msec", lambda s: (s > 0).sum()),
-        outbound_cnt=("param_outbound_bool", "sum"),
-        search_cnt=("param_search_term", lambda s: s.notna().sum())
+    q = (
+        pl.scan_csv(INPUT_PATH, ignore_errors=True, schema_overrides=dtype_overrides)
+        .select(actual_cols) # 필요한 컬럼만 선택해서 읽기
+        .with_columns([
+            pl.from_epoch(pl.col("event_timestamp").cast(pl.Int64), time_unit="us").alias("event_time"),
+            pl.col("event_date").cast(pl.String).str.to_date("%Y%m%d", strict=False).alias("event_date_norm")
+        ])
     )
-    features["view_to_cart_rate"] = features["add_to_cart_count"] / (features["total_page_views"] + 1)
-    print("Features built:", features.shape, flush=True)
 
-    del df
-    gc.collect()
+    # [3] 2단계 집계: 유저 단위 통합 피처 생성 (구매 + 이탈팀 로직 통합)
+    user_features = (
+        q.group_by("user_pseudo_id")
+        .agg([
+            pl.col("event_timestamp").count().alias("total_events"),
+            
+            # (중요) == 연산 결과인 Boolean을 Int32로 바꿔야 sum()이 가능합니다.
+            (pl.col("event_name") == "page_view").cast(pl.Int32).sum().alias("total_page_views"),
+            (pl.col("event_name") == "add_to_cart").cast(pl.Int32).sum().alias("add_to_cart_count"),
+            (pl.col("event_name") == "purchase").cast(pl.Int32).sum().alias("purchase_count"),
+            
+            pl.col("param_engagement_time_msec").mean().alias("avg_engagement_time_msec"),
+            pl.col("param_ga_session_id").n_unique().alias("ga_session_id_count"),
+            pl.col("param_page_location").n_unique().alias("unique_pages"),
+            pl.col("param_ga_session_number").fill_null(0.0).mean().alias("avg_session_number"),
+            
+            # 조건부 카운트들도 모두 캐스팅 적용
+            (pl.col("param_percent_scrolled") >= 50).cast(pl.Int32).sum().alias("scroll_count"),
+            (pl.col("param_engagement_time_msec") > 0).cast(pl.Int32).sum().alias("engaged_cnt"),
+            pl.col("param_outbound").str.to_lowercase()
+              .is_in(["true", "1", "t", "yes"]).cast(pl.Int32).sum().alias("outbound_cnt"),
+            pl.col("param_search_term").is_not_null().cast(pl.Int32).sum().alias("search_cnt")
+        ])
+        .with_columns(
+            (pl.col("add_to_cart_count") / (pl.col("total_page_views") + 1)).alias("view_to_cart_rate")
+        )
+    )
+    
+    #(
+    #     q.group_by("user_pseudo_id")
+    #     .agg([
+    #         # 구매팀 피처
+    #         pl.col("event_name").filter(pl.col("event_name") == "purchase").sum().alias("purchase_count"),
+    #         pl.col("event_name").filter(pl.col("event_name") == "add_to_cart").sum().alias("add_to_cart_count"),
+    #         pl.col("param_ga_session_id").n_unique().alias("ga_session_id_count"), # 무엇 ? 
+    #         pl.col("param_page_location").n_unique().alias("unique_pages"),
+            
+    #         # 이탈팀 피처
+    #         pl.col("event_time").max().alias("last_visit"),
+    #         pl.col("event_name").filter(pl.col("event_name") == "page_view").sum().alias("total_page_views"),
+    #         pl.col("param_engagement_time_msec").mean().alias("avg_engagement_time_msec"), # 결측값은 0으로 채우기 
+    #         pl.col("param_percent_scrolled").filter(pl.col("param_percent_scrolled") >= 50).sum().alias("scroll_count"),
+            
+    #         # 공통 범주형 피처
+    #         pl.col("param_outbound").mode().first().alias("main_outbound_status"),
+
+    #         # 총 이벤트 수 (event_timestamp count)
+    #         pl.col("event_timestamp").count().alias("total_events"),
+    #         # 검색 횟수 (null이 아닌 행 카운트)
+    #         pl.col("param_search_term").is_not_null().sum().alias("search_cnt"),
+    #         # 인게이지먼트 발생 횟수 (시간 > 0)
+    #         (pl.col("param_engagement_time_msec") > 0).sum().alias("engaged_cnt"),
+    #         # 세션 번호 평균 (결측치는 0으로 처리)
+    #         pl.col("param_ga_session_number").fill_null(0).mean().alias("avg_session_number"),
+    #         #  아웃바운드 클릭 수 (True/1/t/yes 조건 통합)
+    #         pl.col("param_outbound").str.to_lowercase()
+    #           .is_in(["true", "1", "t", "yes"]).sum().alias("outbound_cnt"),
+
+    #     ])
+    #     # 집계 직후 전환율(view_to_cart_rate) 연산 (라플라스 스무딩 적용)
+    #     .with_columns(
+    #         (pl.col("add_to_cart_count") / (pl.col("total_page_views") + 1)).alias("view_to_cart_rate")
+    #     )
+    # )
+
+    # 실행 및 Pandas 변환 (Streaming 엔진 사용)
+    print("✅ 데이터 집계 및 최적화 실행 중...", flush=True)
+    features =  user_features.collect(engine="streaming").to_pandas()
+
+    # 메모리 최적화 및 반환
+    # Polars Lazy는 q 객체 자체가 메모리를 거의 쓰지 않지만, 명시적으로 비워줍니다.
+    print(f"Features built: {features.shape}", flush=True)
+    
+    # 불필요한 객체 제거 및 가비지 컬렉션
+    gc.collect() 
+    
     return features
+# ====================== 모델링 ===============================
+# 모델이 없을시 
+def get_or_train_model(path, X, y_condition, model_name):
+    """모델 로드 실패 시 베이스라인 모델을 자동 생성"""
+    if not os.path.exists(path):
+        print(f"⚠️ {model_name} 모델이 없습니다. 임시 모델을 학습합니다.")
+        y = (y_condition).astype(int)
+        # 학습에 방해되는 ID 및 날짜 컬럼 제외
+        X_train = X.select_dtypes(include=['number', 'bool'])
+        
+        model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=2000))
+        model.fit(X_train, y)
+        
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        joblib.dump(model, path)
+        return model
+    return joblib.load(path)
 
+# 모델 있다면 
 def predict_and_save(features: pd.DataFrame):
-    print(f"Step 2: 모델 로드 및 예측 시작 (Model: {MODEL_PATH})", flush=True)
+    print(f"🚀 Step 2: 모델 로드 및 예측 시작 (Model: {PURCHASE_MODEL_PATH})", flush=True)
+    
+    print(f"Step 2: 모델 로드 및 예측 시작 (Model: {PURCHASE_MODEL_PATH})", flush=True)
     feature_cols = [
         "total_events", "total_page_views", "add_to_cart_count", "purchase_count",
         "avg_engagement_time_msec", "ga_session_id_count", "unique_pages",
         "avg_session_number", "scroll_count", "engaged_cnt",
         "outbound_cnt", "search_cnt", "view_to_cart_rate"
     ]
+    # 공통 피처 선택 및 결측치 처리
     X = features[feature_cols].fillna(0)
 
-    # ✅ 모델 파일 체크 및 자동 복구 로직 (DataFrame 에러 방지)
-    if not os.path.exists(MODEL_PATH):
+    # ✅ 모델 파일 체크 및 자동 복구 로직
+    if not os.path.exists(PURCHASE_MODEL_PATH):
         print("⚠️ 모델이 없습니다. 즉석 학습 후 .pkl을 생성합니다.")
         y = (features['purchase_count'] > 0).astype(int)
         model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=2000))
         model.fit(X, y)
-        os.makedirs(os.path.dirname(MODEL_PATH), exist_ok=True)
-        joblib.dump(model, MODEL_PATH)
+        os.makedirs(os.path.dirname(PURCHASE_MODEL_PATH), exist_ok=True)
+        joblib.dump(model, PURCHASE_MODEL_PATH)
     else:
-        model = joblib.load(MODEL_PATH)
-        # 🔍 만약 로드된게 데이터프레임이면 강제 재학습 (팀장님 에러 해결 핵심)
+        model = joblib.load(PURCHASE_MODEL_PATH)
+        # 🔍 pkl이 데이터프레임으로 오인될 경우 해결 (팀장님 요청 사항)
         if isinstance(model, pd.DataFrame):
             print("⚠️ 경고: 로드된 pkl이 데이터프레임입니다. 모델로 새로 학습하여 덮어씁니다.")
             y = (features['purchase_count'] > 0).astype(int)
             model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=2000))
             model.fit(X, y)
-            joblib.dump(model, MODEL_PATH)
+            joblib.dump(model, PURCHASE_MODEL_PATH)
 
-    # 확률 예측
+    # 확률 및 라벨 예측
     probs = model.predict_proba(X)[:, 1]
-    preds = (probs >= THRESHOLD).astype(int)
+    preds = (probs >= P_THRESHOLD).astype(int)
 
-    # T7 테이블 구성
+    # [T7 테이블] 개별 유저 예측 결과
     t7_final = pd.DataFrame({
         "user_pseudo_id": features["user_pseudo_id"],
         "purchase_probability": probs,
         "predicted_purchase": preds,
         "prediction_date": datetime.datetime.now().strftime("%Y-%m-%d"),
-        "churn_probability": 0.0,
+        "churn_probability": 0.0, # 이탈 모델 통합 전 기본값
         "predicted_churn": 0
     })
 
@@ -114,7 +198,7 @@ def predict_and_save(features: pd.DataFrame):
     )
     t7_final["risk_segment"] = "안정"
 
-    # T8 테이블 구성
+    # [T8 테이블] 일일 요약 및 트렌드 데이터
     t8_final = pd.DataFrame([{
         "prediction_date": t7_final["prediction_date"].iloc[0],
         "total_users": len(t7_final),
@@ -123,13 +207,13 @@ def predict_and_save(features: pd.DataFrame):
         "avg_purchase_probability": float(t7_final["purchase_probability"].mean()),
         "high_value_count": int((t7_final["value_segment"] == "고가치").sum()),
         
-        "high_risk_count": int((t7_final["risk_segment"] == "고위험").sum()), # 이탈 모델 합류 전이라 현재는 0
-        "actual_sessions": int(features["ga_session_id_count"].sum()),     # 실제 총 세션 수
-        "actual_revenue": float(features["purchase_count"].sum() * 30000), # 실제 매출 (단가 3만원 가정, 필요시 수정)
-        "trend_purchase_rate": float(features["purchase_count"].sum() / len(features)) # 실제 구매율 (과거 대비 트렌드 확인용)
+        "high_risk_count": 0, 
+        "actual_sessions": int(features["ga_session_id_count"].sum()),
+        "actual_revenue": float(features["purchase_count"].sum() * 30000), # 단가 3만원 가정
+        "trend_purchase_rate": float(features["purchase_count"].sum() / len(features))
     }])
 
-    # 저장
+    # 파일 저장 및 로그
     os.makedirs(OUTPUT_DIR, exist_ok=True)
     t7_path = os.path.join(OUTPUT_DIR, "t7_prediction_result.csv")
     t8_path = os.path.join(OUTPUT_DIR, "t8_prediction_trend.csv")
@@ -137,13 +221,95 @@ def predict_and_save(features: pd.DataFrame):
     t7_final.to_csv(t7_path, index=False)
     t8_final.to_csv(t8_path, index=False)
 
-    print(f"✅ 완료! 모델: {MODEL_PATH}")
+    print(f"✅ 완료! 모델: {PURCHASE_MODEL_PATH}")
     print(f"✅ 완료! T7: {t7_path}\n✅ 완료! T8: {t8_path}", flush=True)
 
 if __name__ == "__main__":
     try:
-        feats = load_and_preprocess()
-        predict_and_save(feats)
+        feats = load_and_preprocess() # 데이터 반환
+        predict_and_save(feats) # 예측 및 저장
     except Exception as e:
         print(f"❌ Error 발생: {e}", flush=True)
         raise
+
+# # 모델이 있을시 (기존)
+# def predict_and_save(features: pd.DataFrame):
+#     print(f"Step 2: 모델 로드 및 예측 시작 (Model: {PURCHASE_MODEL_PATH})", flush=True)
+#     feature_cols = [
+#         "total_events", "total_page_views", "add_to_cart_count", "purchase_count",
+#         "avg_engagement_time_msec", "ga_session_id_count", "unique_pages",
+#         "avg_session_number", "scroll_count", "engaged_cnt",
+#         "outbound_cnt", "search_cnt", "view_to_cart_rate"
+#     ]
+#     X = features[feature_cols].fillna(0)
+
+#     # ✅ 모델 파일 체크 및 자동 복구 로직 (DataFrame 에러 방지)
+#     if not os.path.exists(PURCHASE_MODEL_PATH):
+#         print("⚠️ 모델이 없습니다. 즉석 학습 후 .pkl을 생성합니다.")
+#         y = (features['purchase_count'] > 0).astype(int)
+#         model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=2000))
+#         model.fit(X, y)
+#         os.makedirs(os.path.dirname(PURCHASE_MODEL_PATH), exist_ok=True)
+#         joblib.dump(model, PURCHASE_MODEL_PATH)
+#     else:
+#         model = joblib.load(PURCHASE_MODEL_PATH)
+#         # 🔍 만약 로드된게 데이터프레임이면 강제 재학습 (팀장님 에러 해결 핵심)
+#         if isinstance(model, pd.DataFrame):
+#             print("⚠️ 경고: 로드된 pkl이 데이터프레임입니다. 모델로 새로 학습하여 덮어씁니다.")
+#             y = (features['purchase_count'] > 0).astype(int)
+#             model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=2000))
+#             model.fit(X, y)
+#             joblib.dump(model, PURCHASE_MODEL_PATH)
+
+#     # 확률 예측
+#     probs = model.predict_proba(X)[:, 1]
+#     preds = (probs >= P_THRESHOLD).astype(int)
+
+#     # T7 테이블 구성
+#     t7_final = pd.DataFrame({
+#         "user_pseudo_id": features["user_pseudo_id"],
+#         "purchase_probability": probs,
+#         "predicted_purchase": preds,
+#         "prediction_date": datetime.datetime.now().strftime("%Y-%m-%d"),
+#         "churn_probability": 0.0,
+#         "predicted_churn": 0
+#     })
+
+#     t7_final["value_segment"] = t7_final["purchase_probability"].apply(
+#         lambda x: "고가치" if x >= 0.7 else ("잠재" if x >= 0.4 else "저관여")
+#     )
+#     t7_final["risk_segment"] = "안정"
+
+#     # T8 테이블 구성
+#     t8_final = pd.DataFrame([{
+#         "prediction_date": t7_final["prediction_date"].iloc[0],
+#         "total_users": len(t7_final),
+#         "predicted_purchasers": int(t7_final["predicted_purchase"].sum()),
+#         "predicted_purchase_rate": float(t7_final["predicted_purchase"].mean()),
+#         "avg_purchase_probability": float(t7_final["purchase_probability"].mean()),
+#         "high_value_count": int((t7_final["value_segment"] == "고가치").sum()),
+        
+#         "high_risk_count": int((t7_final["risk_segment"] == "고위험").sum()), # 이탈 모델 합류 전이라 현재는 0
+#         "actual_sessions": int(features["ga_session_id_count"].sum()),     # 실제 총 세션 수
+#         "actual_revenue": float(features["purchase_count"].sum() * 30000), # 실제 매출 (단가 3만원 가정, 필요시 수정)
+#         "trend_purchase_rate": float(features["purchase_count"].sum() / len(features)) # 실제 구매율 (과거 대비 트렌드 확인용)
+#     }])
+
+#     # 저장
+#     os.makedirs(OUTPUT_DIR, exist_ok=True)
+#     t7_path = os.path.join(OUTPUT_DIR, "t7_prediction_result.csv")
+#     t8_path = os.path.join(OUTPUT_DIR, "t8_prediction_trend.csv")
+    
+#     t7_final.to_csv(t7_path, index=False)
+#     t8_final.to_csv(t8_path, index=False)
+
+#     print(f"✅ 완료! 모델: {PURCHASE_MODEL_PATH}")
+#     print(f"✅ 완료! T7: {t7_path}\n✅ 완료! T8: {t8_path}", flush=True)
+
+# if __name__ == "__main__":
+#     try:
+#         feats = load_and_preprocess()
+#         predict_and_save(feats)
+#     except Exception as e:
+#         print(f"❌ Error 발생: {e}", flush=True)
+#         raise


### PR DESCRIPTION
Summary
- 작성된 구매예측의 ml_predict에 이탈 예측 로직 추가 및 통합 
- 데이터 전처리 :pandas -> polars 변경 
- T7, T8 예측 csv 생성(기존 테이블에 이탈 확률 추가




#23