### PR TITLE
fix: T6 first_traffic_source 컬럼 누락 추가 및 ml_predict.py user_pseudo_id 형 변환 (#31)

### DIFF
--- a/docker/dags/sql/t6_user_feature.sql
+++ b/docker/dags/sql/t6_user_feature.sql
@@ -54,7 +54,9 @@ obs_session_agg AS (
     DATE_DIFF(MAX(session_date), MIN(session_date), DAY)                      AS visit_span_days,
     -- 가장 많이 사용한 기기/유입 채널 추출
     APPROX_TOP_COUNT(session_device, 1)[OFFSET(0)].value                      AS main_device_category,
-    APPROX_TOP_COUNT(session_traffic_source, 1)[OFFSET(0)].value              AS main_traffic_source
+    APPROX_TOP_COUNT(session_traffic_source, 1)[OFFSET(0)].value              AS main_traffic_source,
+    -- 최초 세션의 유입 채널 (session_date, ga_session_id 오름차순 기준 첫 번째 값)
+    ARRAY_AGG(session_traffic_source ORDER BY session_date ASC, ga_session_id ASC LIMIT 1)[SAFE_OFFSET(0)] AS first_traffic_source
   FROM `{project}.{dataset}.T3_session_funnel_table`
   GROUP BY user_pseudo_id
 ),
@@ -135,7 +137,8 @@ SELECT
   COALESCE(j.last_funnel_step, 0) - COALESCE(j.prev_funnel_step, 0)           AS funnel_improvement,        -- 퍼널 진행도 변화
   e.unique_items_viewed,
   s.main_device_category,
-  s.main_traffic_source
+  s.main_traffic_source,
+  s.first_traffic_source   -- 최초 유입 채널
 
 FROM obs_users               AS u
 LEFT JOIN obs_event_agg      AS e ON u.user_pseudo_id = e.user_pseudo_id

--- a/src/ML/ml_predict.py
+++ b/src/ML/ml_predict.py
@@ -126,8 +126,11 @@ def load_and_preprocess():
     print(f"Features built: {features.shape}", flush=True)
     
     # 불필요한 객체 제거 및 가비지 컬렉션
-    gc.collect() 
-    
+    gc.collect()
+
+    # user_pseudo_id를 명시적으로 문자열 타입으로 변환 (BQ 업로드 시 float 추론 방지)
+    features["user_pseudo_id"] = features["user_pseudo_id"].astype(str)
+
     return features
 # ====================== 모델링 ===============================
 # 모델이 없을시 


### PR DESCRIPTION
## Summary

- `t6_user_feature.sql`: `obs_session_agg` CTE에 `first_traffic_source` 컬럼 추가 — 최초 세션 유입 채널을 `ARRAY_AGG(... ORDER BY session_date ASC LIMIT 1)`로 추출하며 최종 SELECT 절에도 반영
- `ml_predict.py`: `load_and_preprocess()` 반환 직전에 `user_pseudo_id.astype(str)` 명시적 변환 추가 — Polars→Pandas 변환 후 float으로 추론되어 BigQuery 업로드 시 타입 불일치 오류 발생하는 버그 수정

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `docker/dags/sql/t6_user_feature.sql` | `obs_session_agg` CTE + SELECT 절에 `first_traffic_source` 추가 |
| `src/ML/ml_predict.py` | `load_and_preprocess()` 반환 전 `user_pseudo_id` → `str` 변환 |

## Test plan

- [ ] t6_user_feature.sql: BigQuery에서 T6 테이블 재생성 후 `first_traffic_source` 컬럼 존재 확인
- [ ] ml_predict.py: `t7_prediction_result.csv`의 `user_pseudo_id` 컬럼 dtype이 `object(str)`인지 확인

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)