### PR TITLE
refactor: 10분 스케줄 변경 및 prediction_date 시뮬레이션 날짜로 수정 (#35)

### DIFF
--- a/docker/dags/daily_bq_update.py
+++ b/docker/dags/daily_bq_update.py
@@ -78,8 +78,8 @@ def load_sql(filename: str) -> str:
 # ---------------------------------------------------------------------------
 with DAG(
     dag_id="daily_bq_update",
-    start_date=pendulum.today("UTC"),   # DAG1과 동일한 시작일 기준
-    schedule_interval="@daily",
+    start_date=pendulum.datetime(2026, 3, 6, 0, 0, 0, tz="UTC"),  # DAG1과 동일한 시작일 고정
+    schedule_interval="0/10 * * * *",  # 매시 00/10/20/30/40/50분 실행 (테스트용, 실제 배포 시 @daily로 복구)
     catchup=False,                      # 과거 날짜 소급 실행 비활성화
     max_active_runs=1,                  # 동시 실행 제한 (DAG1과 순서 보장)
     tags=["analytics", "bigquery"],

--- a/docker/dags/daily_ga4_ingestion.py
+++ b/docker/dags/daily_ga4_ingestion.py
@@ -34,11 +34,14 @@ with open(_SQL_PATH) as f:
 # Python callable: GA4 날짜 계산 (실행일 → 시뮬레이션 GA4 날짜)
 # ---------------------------------------------------------------------------
 def compute_ga4_date(execution_date, **context):
-    dag_start  = context["dag"].start_date
-    delta_days = (execution_date - dag_start).days
-    ga4_date   = GA4_SIMULATION_START.add(days=delta_days)
-    result     = ga4_date.format("YYYYMMDD")
-    print(f"execution_date={execution_date.date()}  →  ga4_date={result}")
+    dag_start       = context["dag"].start_date
+    # 10분 인터벌 단위로 delta 계산 (600초 = 10분 = GA4 1일)
+    # @daily 대신 0/10 * * * * 스케줄 사용 시, 같은 날 여러 실행이 서로 다른 ga4_date를 가짐
+    delta_seconds   = int((execution_date - dag_start).total_seconds())
+    delta_intervals = delta_seconds // 600          # 600초 = 10분 = 1 GA4 일
+    ga4_date        = GA4_SIMULATION_START.add(days=delta_intervals)
+    result          = ga4_date.format("YYYYMMDD")
+    print(f"execution_date={execution_date}  delta={delta_intervals}일  →  ga4_date={result}")
     return result  # XCom으로 자동 push
 
 
@@ -91,8 +94,8 @@ _XCOM_GA4_DATE = "{{ ti.xcom_pull(task_ids='compute_ga4_date') }}"
 
 with DAG(
     dag_id="daily_ga4_ingestion",
-    start_date=pendulum.today("UTC"),   # 배포일 = Day 1 (→ GA4 2021-01-17)
-    schedule_interval="@daily",
+    start_date=pendulum.datetime(2026, 3, 6, 0, 0, 0, tz="UTC"),  # 배포 시점 고정 (재로드 시 delta_days 틀어짐 방지)
+    schedule_interval="0/10 * * * *",  # 매시 00/10/20/30/40/50분 실행 (테스트용, 실제 배포 시 @daily로 복구)
     catchup=False,
     max_active_runs=3,
     tags=["ga4", "ingestion"],

--- a/docker/dags/daily_ml_pipeline.py
+++ b/docker/dags/daily_ml_pipeline.py
@@ -102,10 +102,10 @@ def run_ml_predict(ga4_date: str, **_):
     # 출력 디렉터리 생성
     os.makedirs(OUTPUT_DIR, exist_ok=True)
 
-    # ml_predict.py 실행
+    # ml_predict.py 실행 (ga4_date를 인수로 전달하여 prediction_date를 시뮬레이션 날짜로 저장)
     print(f"ml_predict.py 실행 시작 (ga4_date={ga4_date})")
     result = subprocess.run(
-        ["python", ML_SCRIPT_PATH],
+        ["python", ML_SCRIPT_PATH, ga4_date],
         capture_output=True,
         text=True,
     )
@@ -169,8 +169,8 @@ def upload_to_gcs(ga4_date: str, **_):
 # ---------------------------------------------------------------------------
 with DAG(
     dag_id="daily_ml_pipeline",
-    start_date=pendulum.today("UTC"),   # DAG1과 동일한 시작일 기준
-    schedule_interval="@daily",
+    start_date=pendulum.datetime(2026, 3, 6, 0, 0, 0, tz="UTC"),  # DAG1과 동일한 시작일 고정
+    schedule_interval="0/10 * * * *",  # 매시 00/10/20/30/40/50분 실행 (테스트용, 실제 배포 시 @daily로 복구)
     catchup=False,                      # 과거 날짜 소급 실행 비활성화
     max_active_runs=1,                  # 동시 실행 제한
     tags=["ml", "prediction"],

--- a/src/ML/ml_predict.py
+++ b/src/ML/ml_predict.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 import gc
 import os
+import sys
 import joblib
 import datetime
 from sklearn.linear_model import LogisticRegression
@@ -150,10 +151,25 @@ def get_or_train_model(path, X, y_condition, model_name):
         return model
     return joblib.load(path)
 
-# 모델 있다면 
-def predict_and_save(features: pd.DataFrame):
+# 모델 있다면
+def predict_and_save(features: pd.DataFrame, ga4_date: str = None):
+    """
+    예측 결과를 T7/T8 CSV로 저장한다.
+
+    Args:
+        features: load_and_preprocess()가 반환한 유저별 피처 DataFrame
+        ga4_date: DAG3가 전달하는 GA4 시뮬레이션 날짜 (예: '20210117').
+                  None이면 오늘 날짜를 prediction_date로 사용한다.
+    """
     print(f"🚀 Step 2: 모델 로드 및 예측 시작 (Model: {PURCHASE_MODEL_PATH})", flush=True)
-    
+
+    # ga4_date가 있으면 시뮬레이션 날짜 사용, 없으면 오늘 날짜 fallback
+    if ga4_date:
+        prediction_date = datetime.datetime.strptime(ga4_date, "%Y%m%d").strftime("%Y-%m-%d")
+    else:
+        prediction_date = datetime.datetime.now().strftime("%Y-%m-%d")
+    print(f"prediction_date={prediction_date}", flush=True)
+
     print(f"Step 2: 모델 로드 및 예측 시작 (Model: {PURCHASE_MODEL_PATH})", flush=True)
     p_feature_cols = [
         "total_events", "total_page_views", "add_to_cart_count", "purchase_count",
@@ -261,7 +277,7 @@ def predict_and_save(features: pd.DataFrame):
         "predicted_purchase": p_preds,
         "churn_probability": c_probs,     # 0.0이 아닌 실제 확률값!
         "predicted_churn": c_preds,       # 실제 예측값!
-        "prediction_date": datetime.datetime.now().strftime("%Y-%m-%d")
+        "prediction_date": prediction_date   # GA4 시뮬레이션 날짜 (DAG3 인수) 또는 오늘 날짜
     })
 
     t7_final["value_segment"] = t7_final["purchase_probability"].apply(
@@ -302,8 +318,11 @@ def predict_and_save(features: pd.DataFrame):
 
 if __name__ == "__main__":
     try:
-        feats = load_and_preprocess() # 데이터 반환
-        predict_and_save(feats) # 예측 및 저장
+        # DAG3가 ga4_date를 첫 번째 인수로 전달 (예: "20210117")
+        # 인수가 없으면 None → prediction_date가 오늘 날짜로 fallback
+        ga4_date_arg = sys.argv[1] if len(sys.argv) > 1 else None
+        feats = load_and_preprocess()           # 데이터 반환
+        predict_and_save(feats, ga4_date=ga4_date_arg)  # 예측 및 저장
     except Exception as e:
         print(f"❌ Error 발생: {e}", flush=True)
         raise


### PR DESCRIPTION
## Summary

- 3개 DAG `schedule_interval`: `@daily` → `0/10 * * * *` (매시 00/10/20/30/40/50분)
- 3개 DAG `start_date`: `pendulum.today("UTC")` → `pendulum.datetime(2026, 3, 6, 0, 0, 0, tz="UTC")` 고정 (재로드 시 delta_days 틀어짐 방지)
- `compute_ga4_date` (DAG1): delta 계산을 일 단위 → 10분 인터벌 단위로 변경 (`delta_seconds // 600`)
- `run_ml_predict` (DAG3): subprocess 호출 시 `ga4_date` 인수 전달
- `predict_and_save` (ml_predict.py): `ga4_date` 파라미터 추가, `prediction_date`를 GA4 시뮬레이션 날짜로 저장. `__main__`에서 `sys.argv[1]` 파싱

## 수동 트리거 exec-date 규칙

| GA4 날짜 | exec-date |
|----------|-----------|
| 20210117 (Day 0) | 2026-03-06T00:00:00+00:00 |
| 20210118 (Day 1) | 2026-03-06T00:10:00+00:00 |
| 20210119 (Day 2) | 2026-03-06T00:20:00+00:00 |

## Test plan

- [ ] exec-date=`2026-03-06T00:00:00+00:00`으로 3개 DAG 수동 트리거
- [ ] `output/t7_prediction_result.csv`에서 `prediction_date = 2021-01-17` 확인
- [ ] exec-date=`2026-03-06T00:10:00+00:00`으로 재트리거 → `prediction_date = 2021-01-18` 확인

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)