### PR TITLE
docs: 시연영상 video 태그를 GIF 이미지로 교체

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ OUTPUT_DIR=/app/output \
 python -u /app/src/ML/ml_predict.py"
 
 ### 13. 실행화면 & 시연영상
+시연영상<br>
+![시연영상](docs/시연영상.gif)
 
 구매모델 학습<br>
 ![purchase_model_learn](docs/purchase_model_learn.png)<br>
@@ -288,8 +290,7 @@ MLflow 로깅<br>
 MLflow 실험관리<br>
 ![MLflow](docs/MLflow.png)<br>
 
-시연영상<br>
-<video src="docs/시연영상.mp4" controls width="600"></video>
+
 
 ### 14. DataFlow
 ![DataFlow](docs/DataFlow.png)


### PR DESCRIPTION
GitHub README에서 video 태그가 렌더링되지 않는 문제를 해결하기 위해
시연영상.mp4를 GIF(640px, 10fps)로 변환하여 img 태그로 교체